### PR TITLE
WIP: Make clean-git from haskell.nix more modular

### DIFF
--- a/adapt/README.md
+++ b/adapt/README.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
+Some of the repositories we depend on are structured in various _original_
+ways and it is impossible to just import them and use directly, for example,
+for their library. But we really want their library functions.
+
+Hence, we adapt them to a more sane flake-like structure.

--- a/adapt/haskell-nix.nix
+++ b/adapt/haskell-nix.nix
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+{ haskell-nix-src, nixpkgs }:
+
+let
+  flake = {
+    edition = 201911;
+
+    description = "Alternative Haskell Infrastructure for Nixpkgs";
+
+    outputs = { self, nixpkgs }: {
+      lib = rec {
+        cleanSourceWith = (import "${haskell-nix-src}/lib/clean-source-with.nix" {
+          lib = nixpkgs.lib;
+        }).cleanSourceWith;
+        cleanGit = import "${haskell-nix-src}/lib/clean-git.nix" {
+          lib = nixpkgs.lib;
+          inherit (nixpkgs) runCommand git;
+          inherit cleanSourceWith;
+        };
+      };
+    };
+  };
+
+  haskell-nix = flake.outputs {
+    self = haskell-nix;
+    inherit nixpkgs;
+  };
+
+in haskell-nix

--- a/flake.nix
+++ b/flake.nix
@@ -7,15 +7,11 @@
 
   description = "Serokell Nix infrastructure library";
 
-  outputs = { self, nixpkgs, gitignore }:
+  outputs = { self, nixpkgs, haskell-nix }:
     let
-      # rename
-      gitignore0 = gitignore;
-    in let
       pkgs = nixpkgs {};
-      gitignore = gitignore0 { lib = pkgs.lib; };
     in {
       overlay = import ./overlay { inherit pkgs; };
-      lib = import ./lib { inherit pkgs gitignore; };
+      lib = import ./lib { inherit pkgs haskell-nix; };
     };
 }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -2,36 +2,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ pkgs, gitignore }:
-
-let
-  inherit (pkgs.lib) cleanSourceFilter removePrefix hasPrefix hasSuffix;
-  inherit (gitignore) gitignoreFilter;
-in
+{ pkgs, haskell-nix }:
 
 {
-  /* Ignore files ignored by .gitignore and some other extra stuff.
-   * Also set a constant path name to avoid different hashes on different
-   * systems.
-   */
-   # TODO: Maybe replace with cleanGit from haskell.nix
-  cleanSource = name: path:
-    let
-      ignoreFilter = path: type:
-        let
-          relPath = removePrefix (toString ./. + "/") (toString path);
-          baseName = baseNameOf relPath;
-        in
-          !(
-            baseName == ".gitignore" ||
-            hasPrefix "resources" relPath ||
-            hasSuffix ".md" baseName
-          );
-    in builtins.path {
-      inherit name path;
-      filter = name: type:
-        ignoreFilter name type &&
-        gitignoreFilter path name type &&
-        cleanSourceFilter name type;
-    };
+  src = import ./src.nix { inherit haskell-nix; };
 }

--- a/lib/src.nix
+++ b/lib/src.nix
@@ -17,9 +17,10 @@
   # src: directory to clean. This is typically `./.`.
   cleanGit = name: src:
     haskell-nix.lib.cleanGit {
-      src = haskell-nix.lib.cleanSourceWith {
-        inherit name src;
-      };
+      # For now, we'll use an unsafe operation
+      # FIXME: We probably want to update upstream.
+      src = builtins.unsafeDiscardStringContext
+        (haskell-nix.lib.cleanSourceWith { inherit name src; });
     };
 
   # Restrict the source to only a subdirectory.

--- a/lib/src.nix
+++ b/lib/src.nix
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+###
+# Working with sources
+###
+
+{ haskell-nix }:
+
+{
+  # Clean the source to leave only files tracked by git.
+  #
+  # name: name of the directory.
+  #       Yes it is boring to always specify the name explicitly,
+  #       but this way we guarantee no unexpected issues with caching.
+  # src: direcotry to clean. This is typically `./.`.
+  cleanGit = name: src:
+    haskell-nix.lib.cleanGit {
+      src = haskell-nix.lib.cleanSourceWith {
+        inherit name src;
+      };
+    };
+
+  # Restrict the source to only a subdirectory.
+  #
+  # subDir: name of the subdirectory.
+  # src: original source.
+  #
+  # This function composes well with `cleanGit` above and the expected
+  # usage pattern is:
+  #
+  # ```
+  # src = subdir "backend" (cleanGit "project" ./.);
+  # ```
+  #
+  # or
+  #
+  # ```
+  # let
+  #   topLevel = cleanGit "project" ./.;
+  #   backendSrc = subdir "backend" topLevel;
+  #   fronendSrc = subdir "frontend" topLevel;
+  # in ...
+  # ```
+  subdir = subDir: src:
+    # Doesn't actually clean anything but composes well with `cleanGit`.
+    haskell-nix.lib.cleanSourceWith {
+      inherit src;
+      inherit subDir;
+    };
+}

--- a/lib/src.nix
+++ b/lib/src.nix
@@ -14,7 +14,7 @@
   # name: name of the directory.
   #       Yes it is boring to always specify the name explicitly,
   #       but this way we guarantee no unexpected issues with caching.
-  # src: direcotry to clean. This is typically `./.`.
+  # src: directory to clean. This is typically `./.`.
   cleanGit = name: src:
     haskell-nix.lib.cleanGit {
       src = haskell-nix.lib.cleanSourceWith {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
-    "gitignore": {
+    "haskell-nix": {
         "branch": "master",
-        "description": "Nix function for filtering local git sources",
-        "homepage": "",
-        "owner": "hercules-ci",
-        "repo": "gitignore",
-        "rev": "f9e996052b5af4032fe6150bba4a6fe4f7b9d698",
-        "sha256": "0jrh5ghisaqdd0vldbywags20m2cxpkbbk5jjjmwaw0gr8nhsafv",
+        "description": "Alternative Haskell Infrastructure for Nixpkgs",
+        "homepage": "https://input-output-hk.github.io/haskell.nix",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "9643db390128f2de9e9cec14f73687139a28c197",
+        "sha256": "1mc9w8dzhxj1ar0qzaahlrx8b6c5d1b0s0ragpjah3dbb74ni0jk",
         "type": "tarball",
-        "url": "https://github.com/hercules-ci/gitignore/archive/f9e996052b5af4032fe6150bba4a6fe4f7b9d698.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/9643db390128f2de9e9cec14f73687139a28c197.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,0 +1,14 @@
+let pkgs = import (import ../nix/sources.nix).nixpkgs { };
+in with import ../.;
+with lib.src; {
+  no-hash-mismatch = (toString (cleanGit "test" ./test-foo))
+    == (toString (cleanGit "test" ./test-bar));
+  cleans-git = let
+    commit = pkgs.lib.commitIdFromGitRepo ../.git;
+    githubSrc = builtins.fetchGit {
+      url = "https://github.com/serokell/serokell.nix";
+      rev = commit;
+    };
+  in (toString (cleanGit "serokell.nix" githubSrc))
+  == (toString (cleanGit "serokell.nix" ../.));
+}

--- a/tests/test-bar/file
+++ b/tests/test-bar/file
@@ -1,0 +1,1 @@
+This is a check to see if hashes match for the same files

--- a/tests/test-foo/file
+++ b/tests/test-foo/file
@@ -1,0 +1,1 @@
+This is a check to see if hashes match for the same files


### PR DESCRIPTION
I’m trying to reuse IOHK’s `cleanGit`. The idea is that I want to be able to first clean the top-level dir, then, if needed, restrict all of it to a subdir.

The problem is that, apparently, haskell.nix’s git doesn’t work without a `subDir` argument :/.

The test case for this branch is:

```
nix-build -E '(import <nixpkgs> {}).stdenv.mkDerivation { name = "test"; src = (import ./.).lib.src.cleanGit "test" ./.; }'
```

it gives me:

```
error: the string '/nix/store/ipg5hw6pzqpx3sy4zxqjxfa7912lb9mw-test/.reuse/dep5' is not allowed to refer to a store path (such as '/nix/store/ipg5hw6pzqpx3sy4zxqjxfa7912lb9mw-test'), at /nix/store/cl038kzg67j1d6f83zxqlzbmi00kjwif-source/lib/clean-git.nix:34:23
```

I suspect that somewhere inside the `cleanGit` filter they collect strings returned by `git` and this strings retain some context that Nix doesn’t like, so we’ll need to `unsafeDiscardStringContext` it. However I have no idea why it suddenly works if I add a `subDir` to the upstream `cleanGit` invocation.