### PR TITLE
[OPS-1085] vault-secrets: Add approlePrefix option

### DIFF
--- a/modules/vault-secrets.nix
+++ b/modules/vault-secrets.nix
@@ -50,7 +50,7 @@ let
 
         environmentFile = mkOption {
           type = with types; str;
-          default = "/root/vault-secrets.env.d/${name}";
+          default = "/root/vault-secrets.env.d/${cfg.approlePrefix}-${name}";
           example = "/root/service.sh";
           description = ''
             Path to a file that contains the necessary environment variables for
@@ -151,6 +151,14 @@ in
           the module.
         '';
       };
+
+      approlePrefix = mkOption {
+        type = with types; str;
+        default = "";
+        description = ''
+          Prepended to the secret name for resolving the environmentFile path.
+        '';
+      }
 
       outPathPrefix = mkOption {
         type = with types; str;

--- a/modules/vault-secrets.nix
+++ b/modules/vault-secrets.nix
@@ -50,7 +50,7 @@ let
 
         environmentFile = mkOption {
           type = with types; str;
-          default = "/root/vault-secrets.env.d/${cfg.approlePrefix}-${name}";
+          default = "/root/vault-secrets.env.d/${if cfg.approlePrefix != null then "${cfg.approlePrefix}-${name}" else "${name}"}";
           example = "/root/service.sh";
           description = ''
             Path to a file that contains the necessary environment variables for
@@ -153,12 +153,12 @@ in
       };
 
       approlePrefix = mkOption {
-        type = with types; str;
-        default = "";
+        type = with types; nullOr str;
+        default = null;
         description = ''
-          Prepended to the secret name for resolving the environmentFile path.
+          Prepended to the secret name for resolving the default environmentFile path.
         '';
-      }
+      };
 
       outPathPrefix = mkOption {
         type = with types; str;


### PR DESCRIPTION
Allow to set a system-wide prefix used to resolve the EnvironmentFile path used
for authentication.

This allows us to prefix AppRole names for pseudo-namespacing, along with the
environment file provisioning script, without also having to prefix every secret
name as well.