### PR TITLE
Enable nix fallback in case wasabi dies

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -34,6 +34,9 @@
   nix.binaryCachePublicKeys = ["serokell-1:aIojg2Vxgv7MkzPJoftOO/I8HKX622sT+c0fjnZBLj0="];
 
   nix.extraOptions = ''
+    # Allow CI to work when wasabi dies
+    fallback = true
+
     # https://github.com/NixOS/nix/issues/1964
     tarball-ttl = 0
 


### PR DESCRIPTION
Wasabi died again, and our CI died with it. Prevent this in the future by allowing Nix to build locally in case substitution fails.