### PR TITLE
[OPS-1003] acme.sh: let configured group access the certificate

### DIFF
--- a/modules/acme-sh.nix
+++ b/modules/acme-sh.nix
@@ -110,7 +110,7 @@ in
         chmod 755 ${cfg.stateDir}
         mkdir -p "${statePath}"
         chown -R '${user}:${group}' "${statePath}"
-        chmod 700 "${statePath}"
+        chmod 750 "${statePath}"
         rm -f "${statePath}/renewed"
       '';
       environment.LE_WORKING_DIR = statePath;


### PR DESCRIPTION
acme.sh allows setting a group for the certificate directory, but the
mode needs to be changed to let the group actually access it.

This change does not make existing setups less secure, because the group
is 'root' by default.