### PR TITLE
Use distinct name for our oauth2_proxy fork rather than override it

### DIFF
--- a/modules/services/oauth2_proxy.nix
+++ b/modules/services/oauth2_proxy.nix
@@ -94,7 +94,7 @@ in
 
     package = mkOption {
       type = types.package;
-      default = pkgs.oauth2_proxy;
+      default = pkgs.serokell-oauth2_proxy;
       defaultText = "pkgs.oauth2_proxy";
       description = ''
         The package that provides oauth2_proxy.

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -12,7 +12,7 @@ in
   # Uses sources.mix-to-nix and sources.gitignore
   nixUnstable = inputs.nix-unstable.defaultPackage.${final.system};
 
-  oauth2_proxy = callPackage ./oauth2_proxy { };
+  serokell-oauth2_proxy = callPackage ./oauth2_proxy { };
   youtrack = callPackage ./youtrack.nix { };
 
   build = {


### PR DESCRIPTION
We don't need the features from our fork for anything except
serokell-website (and it's possible that serokell-website does not need
these features anymore as well), and it has some unfixed
vulnerabilities (https://github.com/oauth2-proxy/oauth2-proxy/security/advisories/GHSA-5m6c-jp6f-2vcv), so we want to use our fork only for serokell-website
and to be able to use upstream package for everything else.

Related issue: https://issues.serokell.io/issue/INT-158