### PR TITLE
[OPS-1144] Remove haskell.nix input to fix the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
   inputs = {
     nixpkgs.url = "github:serokell/nixpkgs";
     nix-unstable.url = "github:nixos/nix";
-    haskell-nix.url = "github:input-output-hk/haskell.nix/bd45da822d2dccdbb3f65d0b52dd2a91fd65ca4e";
 
     gitignore-nix = {
       url = "github:hercules-ci/gitignore.nix";


### PR DESCRIPTION
`nix flake` commands from nix-unstable don't work currently because the
haskell.nix pin is old and it's incompatible with the pinned
nix-unstable. The haskell.nix input in this flake is not used anywhere,
so it should be ok to just remove it to fix this problem