### PR TITLE
[INT-147] Update 'checkTrailingWhitespace'

### DIFF
--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -28,7 +28,7 @@ in
     * Check the given target path for files with trailing whitespace.
     */
     checkTrailingWhitespace = src: final.build.runCheck ''
-      files=$(grep --recursive --files-with-matches --binary-files=without-match '[[:blank:]]$' "${src}" || true)
+      files=$(grep --recursive --exclude-dir LICENSES --exclude '*.patch' --files-with-matches --binary-files=without-match '[[:blank:]]$' "${src}" || true)
       if [[ ! -z $files ]]; then
         echo 'Files with trailing whitespace:'
         for f in "''${files[@]}"; do


### PR DESCRIPTION
Problem: `checkTrailingWhitespace` checks all files for trailing
whitespaces except for binary files. However, there are more files
we want to exclude:
1. We want to exclude `.patch` files because patched code may have
trailing whitespaces, sometimes it's out of our control.
2. We want to exclude licenses because they may contain trailing
whitespaces and normally licenses should be copy-pasted as is.
Our licenses normally don't contain trailing whitespaces, and even
if some license does, we can remove them. But removing them from
licenses that apply to code we copy-pasted is not perfect, we'd
rather not do that.

Solution: update `checkTrailingWhitespace` to exclude `LICENSES`
directory and `*.patch` files.

## To be discussed

1. I see that we use mere `grep` that can also scan files outside of the repo. For example, for me it also scans `.git` which we don't want to scan. I suppose on CI we somehow ensure that `${src}` contains only clean repo checkout and nothing else (even no `.git` folder), but anyway don't we want to use `git grep` or `git ls-files` to definitely avoid all other files, at least for local runs?
2. Why do we have `''` in `"''${files[@]}";`?
3. What's the purpose of `sed -re "s|${src}/||"`?