### PR TITLE
[OPS-821] Bump nixpkgs, update util-linux package name in acme-sh module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1601640588,
-        "narHash": "sha256-EKCgoeOA5i3DQQx2lfyzvjwCiklnSCXsnHzh9gg1AD4=",
+        "lastModified": 1612858101,
+        "narHash": "sha256-XJ8WVB+z3LxUTdan8K+kiL/Frhdu9JoUeLnBm7zYmmQ=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "1e22f7603d223a67e7cd219939e1c1042419ff24",
+        "rev": "11db098dcba5846805c42d7429854cd0af58645a",
         "type": "github"
       },
       "original": {

--- a/modules/acme-sh.nix
+++ b/modules/acme-sh.nix
@@ -103,7 +103,7 @@ in
         EnvironmentFile = keyFile;
         SuccessExitStatus = "0 2";
       };
-      path = with pkgs; [ acme-sh systemd utillinuxMinimal procps ];
+      path = with pkgs; [ acme-sh systemd util-linuxMinimal procps ];
       preStart = ''
         mkdir -p ${cfg.stateDir}
         chown 'root:root' ${cfg.stateDir}


### PR DESCRIPTION
`utillinuxMinimal` was renamed to `util-linuxMinimal` in https://github.com/NixOS/nixpkgs/commit/bc49a0815ae860010b4d593b02f00ab6f07d50ea