### PR TITLE
Add systemd hardening profiles

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -12,7 +12,7 @@ rec {
   foldExtensions = builtins.foldl' lib.composeExtensions (_: _: { });
   pkgsWith = p: e: p.extend (foldExtensions e);
 
-  systemd = import ./systemd.nix;
+  systemd = import ./systemd;
 
   types = import ./types.nix { inherit lib; };
 }

--- a/lib/systemd/default.nix
+++ b/lib/systemd/default.nix
@@ -1,0 +1,7 @@
+{
+
+  hardeningProfiles = import ./profiles.nix;
+
+  hardenServices = import ./harden-services.nix;
+
+}

--- a/lib/systemd/harden-services.nix
+++ b/lib/systemd/harden-services.nix
@@ -1,0 +1,9 @@
+{ config, lib, ... }:
+let
+  applyProfile = builtins.mapAttrs (_: lib.mkDefault);
+  profiles = import ./profiles.nix;
+in with profiles; {
+  systemd.services = {
+    postgresql.serviceConfig = lib.mkIf (config.services.postgresql.enable) (applyProfile backend_unix_socket);
+  };
+}

--- a/lib/systemd/profiles.nix
+++ b/lib/systemd/profiles.nix
@@ -1,6 +1,6 @@
 rec {
   # Exposure 0.0, but can't really do anything
-  hardeningProfiles.isolate = {
+  isolate = {
     PrivateNetwork = "yes";
     # CapabilityBoundingSet = [
     #   "~CAP_(CHOWN|FSETID|SETFCAP)"
@@ -74,11 +74,11 @@ rec {
       "~@cpu-emulation"
       "~@obsolete"
     ];
-    AmbientCapabilities = "";
+    AmbientCapabilities = [ "" ];
     RestrictRealtime = "yes";
     # Not sure when to really use this
     # RootDirectory = "";
-    SupplementaryGroups = "";
+    SupplementaryGroups = [ "" ];
     Delegate = "no";
     LockPersonality = "yes";
     MemoryDenyWriteExecute = "yes";
@@ -88,7 +88,7 @@ rec {
     ProcSubset = "pid";
   };
   # Exposure 1.1 OK, suitable for most of our backends
-  hardeningProfiles.backend = hardeningProfiles.isolate // {
+  backend = isolate // {
     RestrictAddressFamilies = [
       "AF_INET"
       "AF_UNIX" # For postgresql etc
@@ -98,7 +98,7 @@ rec {
     PrivateNetwork = "no";
   };
   # Exposure 0.8 OK, suitable for backends that listen on UNIX sockets only
-  hardeningProfiles.backend_unix_socket = hardeningProfiles.backend // {
+  backend_unix_socket = backend // {
     RestrictAddressFamilies = [ "AF_UNIX" ];
   };
 }


### PR DESCRIPTION
Adds lib/systemd.nix, which contains hardening profiles for systemd
units. isolate is the best one, but it will break most useful units
from working; backend is for a typical backend application, it allows
some restricted networking, and backend_unix_sockets allows only UNIX
socket networking.
