### PR TITLE
Harden nginx options

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -67,21 +67,14 @@
       }
       add_header Strict-Transport-Security $hsts_header;
 
-      # Enable CSP for your services.
-      #add_header Content-Security-Policy "script-src 'self'; object-src 'none'; base-uri 'none';" always;
-
       # Minimize information leaked to other domains
-      add_header 'Referrer-Policy' 'origin-when-cross-origin';
+      add_header 'Referrer-Policy' 'strict-origin-when-cross-origin';
 
       # Disable embedding as a frame
       add_header X-Frame-Options DENY;
 
       # Prevent injection of code in other mime types (XSS Attacks)
       add_header X-Content-Type-Options nosniff;
-
-      # Enable XSS protection of the browser.
-      # May be unnecessary when CSP is configured properly (see above)
-      add_header X-XSS-Protection "1; mode=block";
     '';
   };
 

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -55,9 +55,37 @@
     appendHttpConfig = ''
       if_modified_since off;
     '';
+    recommendedGzipSettings = lib.mkDefault true;
     recommendedOptimisation = lib.mkDefault true;
     recommendedProxySettings = lib.mkDefault true;
     recommendedTlsSettings = lib.mkDefault true;
+    commonHttpConfig = ''
+      # Add HSTS header with preloading to HTTPS requests.
+      # Adding this header to HTTP requests is discouraged
+      map $scheme $hsts_header {
+          https   "max-age=31536000; includeSubdomains; preload";
+      }
+      add_header Strict-Transport-Security $hsts_header;
+
+      # Enable CSP for your services.
+      #add_header Content-Security-Policy "script-src 'self'; object-src 'none'; base-uri 'none';" always;
+
+      # Minimize information leaked to other domains
+      add_header 'Referrer-Policy' 'origin-when-cross-origin';
+
+      # Disable embedding as a frame
+      add_header X-Frame-Options DENY;
+
+      # Prevent injection of code in other mime types (XSS Attacks)
+      add_header X-Content-Type-Options nosniff;
+
+      # Enable XSS protection of the browser.
+      # May be unnecessary when CSP is configured properly (see above)
+      add_header X-XSS-Protection "1; mode=block";
+
+      # This might create errors
+      proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
+    '';
   };
 
   security.acme = {

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -82,9 +82,6 @@
       # Enable XSS protection of the browser.
       # May be unnecessary when CSP is configured properly (see above)
       add_header X-XSS-Protection "1; mode=block";
-
-      # This might create errors
-      proxy_cookie_path / "/; secure; HttpOnly; SameSite=strict";
     '';
   };
 

--- a/modules/services/nginx.nix
+++ b/modules/services/nginx.nix
@@ -18,7 +18,7 @@ in
     };
   };
 
-  config = mkIf cfg.openFirewall {
+  config = mkIf (cfg.enable && cfg.openFirewall) {
     # TODO: this obviously doesn't work if custom ports are used, but that
     # can be added later to the module, API won't have to be changed.
     networking.firewall.allowedTCPPorts = [ 80 443 ];


### PR DESCRIPTION
I've made `openFirewall` from our own `nginx` module only affect the configuration when nginx is enabled, enabled `recommendedGzipSettings` (this is pretty standard though we do not use this anywhere else, is there any reason?), and copied the `commonHttpConfig` from https://nixos.wiki/wiki/Nginx - we should heavily scrutinize these options as they have the ability to cause many issues, the only important part we really want is the HSTS header.