### PR TITLE
[OPS-1176] Create a module for common ec2 setup, add a fix for network services failing on boot

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
       nginx = import ./modules/services/nginx.nix;
       upload-daemon = import ./modules/services/upload-daemon.nix;
       hetzner-cloud = import ./modules/virtualization/hetzner-cloud.nix;
+      ec2 = import ./modules/virtualization/ec2.nix;
     };
   } // flake-utils.lib.eachDefaultSystem (system:
     let

--- a/modules/virtualization/ec2.nix
+++ b/modules/virtualization/ec2.nix
@@ -1,0 +1,9 @@
+{ config, lib, pkgs, modulesPath, ... }:
+
+{
+  # standard ec2 setup
+  imports = [ "${modulesPath}/virtualisation/amazon-image.nix" ];
+
+  # amazon-init service fetches system config from userdata, we don't need it
+  virtualisation.amazon-init.enable = false;
+}

--- a/modules/virtualization/ec2.nix
+++ b/modules/virtualization/ec2.nix
@@ -6,4 +6,9 @@
 
   # amazon-init service fetches system config from userdata, we don't need it
   virtualisation.amazon-init.enable = false;
+
+  # By default 'network-online.target' is activated as soon as either an ipv4
+  # or an ipv6 address has been assigned. But for AWS instances we want to wait
+  # for an ipv4 address, because DNS resolving will not work without it
+  networking.dhcpcd.wait = lib.mkDefault "ipv4";
 }


### PR DESCRIPTION
I've noticed that acme and vault-secrets services may fail during boot, complaining about dns server not set up. It happens when an ipv6 address is assigned before an ipv4 address, so making dhcp always wait for an ipv4 address before starting other services will fix it. I've made a config for it with other common ec2 setup, so we can reuse it across all repos.