### PR TITLE
[OPS-1190] CI: print full logs for `nix flake check`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,4 @@
 steps:
   - label: Check Nix flake
     commands:
-      - nix-shell --run 'nix --experimental-features "nix-command flakes" flake check'
+      - nix-shell --run 'nix --experimental-features "nix-command flakes" flake check -L'


### PR DESCRIPTION
Without '-L' nix only prints logs on failure, and only the last 10
lines of them