### PR TITLE
Allow adding extra groups to users and wheel users

### DIFF
--- a/modules/serokell-users.nix
+++ b/modules/serokell-users.nix
@@ -19,11 +19,25 @@ in
       example = [ "gosha" "masha" ];
     };
 
+    wheelUsersExtraGroups = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      description = "Extra groups added to users in wheelUsers";
+      example = [ "docker" ];
+    };
+
     regularUsers = mkOption {
       default = [ ];
       type = types.listOf types.str;
       description = "Regular users";
       example = [ "misha" "vasya" "petya" ];
+    };
+
+    regularUsersExtraGroups = mkOption {
+      default = [ ];
+      type = types.listOf types.str;
+      description = "Extra groups added to all users";
+      example = [ "systemd-journal" ];
     };
   };
 
@@ -44,7 +58,8 @@ in
     users.users = lib.genAttrs allUsers (name: {
       isNormalUser = true;
       openssh.authorizedKeys.keys = ssh-keys.${name};
-      extraGroups = lib.optionals (elem name cfg.wheelUsers) [ "wheel" ];
+      extraGroups = cfg.regularUsersExtraGroups ++
+        (lib.optionals (elem name cfg.wheelUsers) ([ "wheel" ] ++ cfg.wheelUsersExtraGroups));
     });
 
     # give all users access to systemd logs


### PR DESCRIPTION
This does not break API. All existing code should continue to work as before. This feature is opt-in.

Particular use cases I have in mind:

* Adding all wheel users to `docker`, so they don't have to `sudo` every time.
* Setting up group-based `sudo` rules and adding all regular users to that group.
* Specific services that allow granting certain privileges based on groups without needing `sudo`.