### PR TITLE
[OPS-1197] acme.sh: add dependency on consul when consul lock is used

### DIFF
--- a/modules/acme-sh.nix
+++ b/modules/acme-sh.nix
@@ -92,7 +92,10 @@ in
   config = {
     systemd.services = lib.mapAttrs' (name: value: lib.nameValuePair "acme-sh-${name}" (with value; {
       description = "Renew ACME Certificate for ${name}";
-      after = [ "network.target" "network-online.target" ];
+      after =
+        [ "network.target" "network-online.target" ]
+        # wait for consul if we use it for locking
+        ++ optional (consulLock != null) [ "consul.service" ];
       wants = [ "network-online.target" ];
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
Make sure acme.sh does not start before consul during booting or
configuration switch.