### PR TITLE
[OPS-1197] Fix typo in acme-sh dependency on consul

### DIFF
--- a/modules/acme-sh.nix
+++ b/modules/acme-sh.nix
@@ -95,7 +95,7 @@ in
       after =
         [ "network.target" "network-online.target" ]
         # wait for consul if we use it for locking
-        ++ optional (consulLock != null) [ "consul.service" ];
+        ++ lib.optionals (consulLock != null) [ "consul.service" ];
       wants = [ "network-online.target" ];
       serviceConfig = {
         Type = "oneshot";


### PR DESCRIPTION
https://github.com/serokell/serokell.nix/pull/38 didn't invoke `optional` correctly