### PR TITLE
[OPS-1202] Bump nixpkgs, change `stdenv.lib` to `lib`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1615307759,
-        "narHash": "sha256-KpzbA2Uf7ZSuu+Q7fAA1DBiY319HrU1QbjzsmgL3I8w=",
+        "lastModified": 1617871354,
+        "narHash": "sha256-3sCuJbCke12dnvude2nxk2isrGPdvZT3uM9A/fcb1Hs=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "25cb6c920e31f80cc4c4559c840c5753d4a9012f",
+        "rev": "fd8bfa0b61ac80181e8e39abde9004e75dc7045e",
         "type": "github"
       },
       "original": {

--- a/overlay/youtrack.nix
+++ b/overlay/youtrack.nix
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ stdenv, makeWrapper, jre, gawk }:
+{ lib, stdenv, makeWrapper, jre, gawk }:
 
 let
   rev = builtins.fromJSON (builtins.readFile ./youtrack_rev.json);
@@ -24,12 +24,12 @@ stdenv.mkDerivation rec {
     runHook preInstall
     makeWrapper ${jre}/bin/java $out/bin/youtrack \
       --add-flags "\$YOUTRACK_JVM_OPTS -jar $jar" \
-      --prefix PATH : "${stdenv.lib.makeBinPath [ gawk ]}" \
+      --prefix PATH : "${lib.makeBinPath [ gawk ]}" \
       --set JRE_HOME ${jre}
     runHook postInstall
   '';
 
-  meta = with stdenv.lib; {
+  meta = with lib; {
     description = "Issue tracking and project management tool for developers";
     maintainers = with maintainers; [ yorickvp ];
     # https://www.jetbrains.com/youtrack/buy/license.html


### PR DESCRIPTION
`stdenv.lib` was deprecated in https://github.com/NixOS/nixpkgs/commit/6717246373541f92ac8d044c6ad1224700686a47 and will be removed in the next NixOS release