### PR TITLE
[OPS-1230] Disable dhcpcd for docker network interfaces to fix EC2 NTP

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -25,6 +25,12 @@
     disabledCollectors = [ "timex" ];
   };
 
+  # veth* are created by docker and don't require DHCP. Disabling it also
+  # avoids issues with EC2 instances, because otherwise dhcpcd creates 169.254.0.0/16
+  # route, which breaks access to AWS metadata and AWS NTP server.
+  # nixpkgs issue: https://github.com/NixOS/nixpkgs/issues/109387
+  networking.dhcpcd.denyInterfaces = [ "veth*" ];
+
   services.mysql.package = lib.mkOptionDefault pkgs.mariadb;
   services.postgresql.package = lib.mkOptionDefault pkgs.postgresql_12;
 


### PR DESCRIPTION
Having dhcpcd for docker interfaces causes it to create `169.254.0.0/16` route for link-local routing (because it does not get a DHCP offer), and it breaks access to the default AWS NTP server, and breaks time synchronization for EC2 instances. This issue is described in https://github.com/NixOS/nixpkgs/issues/109389.

Disabling dhcpcd for interfaces matching `veth*` fixes it. It's unclear if there can be other interfaces named `veth*`, which are not created by docker and actually require DHCP, but we definitely don't have that in our infrastructure.