### PR TITLE
Use composeManyExtensions instead of custom foldExtensions implementation

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -9,7 +9,7 @@ rec {
 
   # Extend nixpkgs with multiple overlays
   #   pkgs = pkgsWith nixpkgs.legacyPackages.${system} [ inputs.serokell-nix.overlay ];
-  foldExtensions = builtins.foldl' lib.composeExtensions (_: _: { });
+  foldExtensions = lib.composeManyExtensions;
   pkgsWith = p: e: p.extend (foldExtensions e);
 
   systemd = import ./systemd;


### PR DESCRIPTION
Added in <https://github.com/nixos/nixpkgs/commit/c3b35f21f78a3d23aaf40b70fe8865598ddc6729>
