### PR TITLE
Remove `foldExtensions`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -9,8 +9,7 @@ rec {
 
   # Extend nixpkgs with multiple overlays
   #   pkgs = pkgsWith nixpkgs.legacyPackages.${system} [ inputs.serokell-nix.overlay ];
-  foldExtensions = builtins.foldl' lib.composeExtensions (_: _: { });
-  pkgsWith = p: e: p.extend (foldExtensions e);
+  pkgsWith = p: e: p.extend (lib.composeManyExtensions e);
 
   systemd = import ./systemd;
 


### PR DESCRIPTION
It was added to nixpkgs as `composeManyExtensions` https://github.com/NixOS/nixpkgs/commit/c3b35f21f78a3d23aaf40b70fe8865598ddc6729

It seems like we didn't import it anywhere, so it's trivial to remove it