### PR TITLE
Fix acme.sh (by switching back to letsencrypt)

### DIFF
--- a/modules/acme-sh.nix
+++ b/modules/acme-sh.nix
@@ -38,6 +38,11 @@ submod = with lib;{
     description = "Group running the ACME client.";
   };
 
+  server = mkOption {
+    type = types.str;
+    default = "letsencrypt";
+    description = "Certificate Authority to use";
+  };
   dns = mkOption {
     type = dnstype;
   };
@@ -122,7 +127,7 @@ in
         mapDomain = name: dns: ''-d "${name}" --dns ${dns}'';
         primary = mapDomain mainDomain domains."${mainDomain}";
         domainsStr = lib.concatStringsSep " " ([primary] ++ (lib.remove primary (lib.mapAttrsToList mapDomain domains)));
-        cmd = ''acme.sh --issue ${lib.optionalString (!production) "--test"} ${domainsStr} --reloadcmd "touch ${statePath}/renewed" --syslog 6 > /dev/null'';
+        cmd = ''acme.sh --server ${server} --issue ${lib.optionalString (!production) "--test"} ${domainsStr} --reloadcmd "touch ${statePath}/renewed" --syslog 6 > /dev/null'';
       in
         if consulLock == null then ''
         ${cmd}


### PR DESCRIPTION
acme.sh [switched][1] to using ZeroSSL by default, and now require an email
address. This broke our module. Which I think is good, since it actually
gives us a good chance to switch back to trusted LE instead of rather sketchy
ZeroSSL.

[1]: https://github.com/acmesh-official/acme.sh/commit/d0b514890a28d13e83bb06efcfb14651e83360c5
