### PR TITLE
ciBuildOptions for haskell.nix packages

### DIFF
--- a/lib/haskell.nix
+++ b/lib/haskell.nix
@@ -93,6 +93,66 @@ let
         else lib.foldl (l: r: l // r) {};
 
     in lib.zipAttrsWith combineOutputs (map flakeForGhc (ghcVersions ++ [null]));
+
+
+  /* Set haskell.nix package config options for all project (local) packages.
+
+     This is similar to `$local` in stack.yaml in that it applies only
+     to packages that are part of the current project.
+     Unlike in stack.yaml, you can set any haskell.nix options here.
+
+     Input: attrset of configuration options to set.
+     Output: a module that you add to the `modules` list when building a project.
+
+     Example:
+       pkgs.haskell-nix.stackProject {
+          # <...>
+          modules = [
+            (optionsLocalPackages = {
+              ghcOptions = [ "-Werror" ];
+            })
+          ];
+       };
+  */
+  optionsLocalPackages = values: { lib, ... }: {
+    # XXX: Oh boy, is this a hack!
+    #      A clean solution is currently impossible: https://github.com/input-output-hk/haskell.nix/issues/1282
+    #      This hack is from: https://github.com/input-output-hk/haskell.nix/issues/298#issuecomment-767936405
+    options.packages = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule ({ config, ... }: {
+        config = lib.mkIf config.package.isLocal values;
+      }));
+    };
+  };
+
+  /* Set project build options suitable for a CI build.
+
+     This will:
+       - Enable `-Werror` for project packages.
+       - Build Haddock for project packages only.
+
+     Example:
+       pkgs.haskell-nix.stackProject {
+          <...>
+          modules = [
+            ciBuildOptions
+          ];
+       };
+  */
+  ciBuildOptions = {
+    imports =
+      [ (optionsLocalPackages {
+          ghcOptions = [ "-Werror" ];
+          doHaddock = true;
+        })
+      ];
+    config = {
+      doHaddock = false;
+    };
+  };
+
 in {
   inherit makeFlake;
+
+  inherit optionsLocalPackages ciBuildOptions;
 }


### PR DESCRIPTION
Provide a standard set of build options for CI builds of haskell.nix packages: `-Werror`, Haddock, etc.

(This PR depends on #51 (it does not really depend on it functionally, but it is that other PR that starts the Haskell lib).)