### PR TITLE
fix: Correctly request GHC in makeFlake

### DIFF
--- a/lib/haskell.nix
+++ b/lib/haskell.nix
@@ -69,15 +69,15 @@ let
 
       flakeForGhc = ghcVersion:
         let
-          ghc =
+          compiler-nix-name =
             if ghcVersion == null
-            then null  # use default (e.g. from stack.yaml)
-            else haskellNix.compiler."ghc${ghcVersion}";
-          project = projectF (args' // { inherit ghc; });
+            then null
+            else "ghc${ghcVersion}";
+          project = projectF (args' // { inherit compiler-nix-name; });
           prefix =
-              if ghcVersion == null
+              if compiler-nix-name == null
               then ""
-              else "ghc${ghcVersion}:";
+              else "${compiler-nix-name}:";
           fixFlakeOutput = name: output:
             if name == "devShell"
             then output


### PR DESCRIPTION
It turns out, passing `ghc` to *Project functions is deprecated.
The correct thing to do is pass the string name of the compiler as
`compiler-nix-name`. This has something to do with cross-sompilation and
choosing the right compiler in the right pkg set.

Pass `compiler-nix-name` to *Project instead of `ghc`.

This also magically fixed builds with GHC 9.2.1 (they removed the
`Option` newtype in `base`, which broke some packages, including
`hashable`, but the version of `hashable` that fixes this depends on
`ghc-bignum`, which only exists in GHC >=9). I don’t exactly know why,
but it does. Probably something to do with the internals of haskell.nix.