### PR TITLE
Run prometheus process exporter

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -26,6 +26,20 @@
     # Default to /tmp on disk, move it to tmpfs if server big enough
     boot.cleanTmpDir = true;
 
+    services.prometheus.exporters.process = {
+      enable = true;
+      settings.process_names = [
+        {
+          name = "{{.Matches.Wrapped}} {{ .Matches.Args }}";
+          cmdline = [ "^/nix/store[^ ]*/(?P<Wrapped>[^ /]*) (?P<Args>.*)" ];
+        }
+        {
+          name = "{{.Comm}}";
+          cmdline = [ ".+" ];
+        }
+      ];
+    };
+
     services.prometheus.exporters.node = {
       enable = true;
       enabledCollectors = [ "systemd" ];

--- a/modules/wireguard-monitoring.nix
+++ b/modules/wireguard-monitoring.nix
@@ -18,6 +18,7 @@ in {
     # firewall rules for the wireguard interface
     networking.firewall.interfaces.wg0.allowedTCPPorts = [
       9100 # prometheus node exporter
+      9256 # prometheus process exporter
     ];
 
     # enable wireguard
@@ -37,6 +38,9 @@ in {
         publicKey = "gOS8bfFuFJmEpaZa19i2Q62gKAaTyL+XWCJvmxekqy8=";
       }];
     };
+
+    # run process-exporter on the wireguard interface
+    services.prometheus.exporters.process.listenAddress = wireguard-ip;
 
     # run node-exporter on the wireguard interface
     services.prometheus.exporters.node.listenAddress = wireguard-ip;


### PR DESCRIPTION
This should handle all processes by default, the /nix/store regex comes from an example in nixpkgs, then I added an additional wildcard match afterwards to handle all the other processes.