### PR TITLE
Enable earlyoom by default

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -18,6 +18,8 @@
 
   config = {
 
+    services.earlyoom.enable = lib.mkDefault true;
+
     programs.atop.enable = true;
 
     environment.etc."default/atop".text = ''


### PR DESCRIPTION
This should help us tackle issues like those we are having with Agora. I would much rather something dies than a server freezes.