### PR TITLE
More granular process matching

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -38,12 +38,12 @@
       enable = true;
       settings.process_names = [
         {
-          name = "{{.Matches.Wrapped}} {{ .Matches.Args }}";
+          name = "{{ .Matches.Wrapped }} {{ .Matches.Args }}";
           cmdline = [ "^/nix/store[^ ]*/(?P<Wrapped>[^ /]*) (?P<Args>.*)" ];
         }
         {
-          name = "{{.Comm}}";
-          cmdline = [ ".+" ];
+          name = "{{ .Matches.All }}";
+          cmdline = [ "(?P<All>.+)" ];
         }
       ];
     };


### PR DESCRIPTION
so we can see things like `dotnet Tzkt.Sync.dll` and `dotnet Tzkt.Api.dll`, not just `dotnet`