### PR TITLE
[Chore] Add ixahedron's SSH key

### DIFF
--- a/modules/ssh-keys.nix
+++ b/modules/ssh-keys.nix
@@ -115,4 +115,7 @@
   nagasai = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAGmm9Pzat0XD/THSxKFVmZIhWPPv8/vKqti/r/NRXE6 nagasai.sivarathri@serokell.com"
   ];
+  ixahedron = [
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNNXSTDxQNVSvje1+hqzTWVQkry59/dsW6pfYk90nw3lVGlppsB1r5o4kPgs0McTVomK3FZmkPmv+nOszdyovXyPJu0eZgXFXhrBPdtbbpVe+8a9I/GpXiCUpW4bie9NQhcX5jHzYpF8mNTq2V1LadrqN4oCgiDUrfX1V/1K5qbtUR5sBLGRIV51DHYsOiRK/wAqf+aKMRRM/bKBoo/LmftpySpGVr1BH2U0k11u6PJ4pGWlU25BemGuesnkwFOMAwUDQK6+MyKhXvaz4rhDqe6g8wQb04UnvgTzzQo55w9J7pRi4dA8fwXxXTvwCiCq2XOU3CtdW9SkkSTZcPhVpZ ix@hedron"
+  ];
 }


### PR DESCRIPTION
Problem: ixahedron's SSH key isn't in ssh-keys.nix.

Solution: added ixahedron's public key to the ssh-keys.nix list.