### PR TITLE
Ignore arguments in process exporter

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -41,11 +41,11 @@
       settings.process_names = [
         {
           name = "{{ .Matches.Wrapped }} {{ .Matches.Args }}";
-          cmdline = [ "^/nix/store[^ ]*/(?P<Wrapped>[^ /]*) (?P<Args>.*)" ];
+          cmdline = [ "^/nix/store[^ ]*/(?P<Wrapped>[^ /]*)" ];
         }
         {
-          name = "{{ .Matches.All }}";
-          cmdline = [ "(?P<All>.+)" ];
+          name = "{{ .Matches.Command }}";
+          cmdline = [ "(?P<Command>[^ ]+)" ];
         }
       ];
     };


### PR DESCRIPTION
They were cool, I like them, but they absolutely kill prometheus and all of our nodes. Wherever needed we can add granularity for matching specific programs.