### PR TITLE
Update CI command

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,4 @@
 steps:
   - label: Check Nix flake
     commands:
-      - nix-shell --run 'nix --experimental-features "nix-command flakes" flake check -L'
+      - nix flake check -L


### PR DESCRIPTION
Problem: The CI uses `nix-shell` to check this flake. This is not necessary anymore with the updated nix version on the CI server

Solution: Update CI command to `nix flake check -L`