### PR TITLE
Use nixwrapper overlay in common module

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -136,7 +136,9 @@
 
     users.mutableUsers = false;
 
-    nixpkgs.overlays = [ (import ./../overlay inputs) ];
+    nixpkgs.overlays =
+      let nixwrapper = import ../nixwrapper inputs;
+      in [ (import ./../overlay inputs) (nixwrapper.overlays.default) ];
     nix.nixPath = [ "nixpkgs=/etc/nix/nixpkgs" ];
     # A hack to get around Nix not recognizing a runtime dependency on nixpkgs
     environment.etc."nix/nixpkgs".source = "${pkgs.path}";


### PR DESCRIPTION
Problem: 'common' module uses 'nixWrapper' to override default 'nix.package'. However, 'nixWrapper' may be not available when this module is imported.

Solution: Explicitly import overlay from nixwrapper in 'common' module.