### PR TITLE
Add a cgroup wrapper for benchmarking

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,8 @@
       };
       packages = {
         inherit (pkgs) nixUnstable;
+      } // pkgs.lib.optionalAttrs (! lib.hasInfix "darwin" system) {
+        inherit (pkgs) benchwrapper;
       };
 
       checks = nixwrapper.checks.${system};


### PR DESCRIPTION
Problem: Consistently profiling the speed of two versions of software is usually not very reliable due to the processes being interrupted by background tasks, thereby rendering execution speed comparisons nearly useless on busy systems.

Solution: A wrapper that moves all background tasks off of a number of cpus and runs the benchmarks on the newly freed cpus.