### PR TITLE
Fix the benchwrapper's pwd

### DIFF
--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -49,7 +49,7 @@ in
     $sctl set-property --runtime user.slice AllowedCPUs="$sysrange"
 
     # run all arguments as a command using systemd-run inheriting path and limited to $shieldrange cpus
-    $srun --nice=-20 --slice shield -EPATH=$PATH --property=AllowedCPUs="$shieldrange" -t -- "$@"
+    $srun --nice=-20 --slice shield -EPATH=$PATH --property=AllowedCPUs="$shieldrange" --pty --same-dir --collect -- "$@"
 
     cleanup
   '';


### PR DESCRIPTION
Problem: The benchwrapper did not inherit the working directory from the calling shell. This leads to a lot of undefined behaviour

Solution: add the `-d` flag to sytemd-run to inherit the pwd from the calling shell