### PR TITLE
Disable atop service

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -20,7 +20,7 @@
 
     services.earlyoom.enable = lib.mkDefault true;
 
-    programs.atop.enable = true;
+    programs.atop.enable = false;
 
     environment.etc."default/atop".text = ''
       LOGOPTS=""


### PR DESCRIPTION
Problem: the atop service logs in a certain directory and upon restarting the service a script checks wether it needs to update the lockfiles to a new update. that does not work as intended and leads to a *lot* of duplicate files in the log directory

Solution: since atop is not being used currently, it is being disabled