### PR TITLE
Enhance stylish-haskell check

### DIFF
--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -91,7 +91,7 @@ in
           exit_code="0"
           for file in "''${files[@]}"; do
             set +e
-            diff="$("${final.haskellPackages.stylish-haskell}/bin/stylish-haskell" "$file" | diff "$file" -)"
+            diff="$("${final.haskellPackages.stylish-haskell}/bin/stylish-haskell" "$file" | diff -u "$file" -)"
             if [ "$diff" != "" ]; then
                 echo "$file"
                 echo "$diff"


### PR DESCRIPTION
Problem: Standard 'diff' output is not very descriptive in case changes reorder lines in the file.

Solution: Use 'diff -u' instead to give 'git diff'-like diff output.