### PR TITLE
Remove Philipp's ssh key from the config

### DIFF
--- a/modules/serokell-users-options.nix
+++ b/modules/serokell-users-options.nix
@@ -15,7 +15,6 @@ in
       "rvem"
       "cab404"
       "magicrb"
-      "maelstroem"
     ];
     apply = users: default ++ users;
   };

--- a/modules/ssh-keys.nix
+++ b/modules/ssh-keys.nix
@@ -78,10 +78,6 @@
   dmozhevitin = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFjIecdFiY7HHhlpaGtf6Y+14I7QTyZvCBObg1X669MQ <comment>"
   ];
-  # Philipp Herzog
-  maelstroem = [
-    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCoABVjBx1az00D8EBjw9/NS9luqO2lN4Y87/2xsQqPTx9P7aXzfX53TwmU9Wpmp7qOIKykd8GSkBdCizMEzgaGmJl6+Di2GYvEfN0NrsLdBrjmIh7AQyR6UbY7qoTFjZ28864rk9QV9to2R1APL7o1wzdmCrFtTsemV+lw9MglqcPLT+ae2mba9fD84FFDmcSJMg5x1QHrO5GuWg/Ng7SE1eRhDbDmz66+HhdgvRRDJ9VwPGcH5ruXsDKvi/nrLVSxw7afvuM5KcNYoy+9CrA/N10cO5zdn4/q2DLYujkOvAucCDJ4bUEe8q6xEZw1LfCjKWIoFxzt+hetfkjS/Y3wWWTcHfcOx/BV6cOxyAFUGbu9RX/iUpyt8LAfjQv6L1zcD7vxYpfKz88jI/4zL7mHwILg+XQklBeiBsEQ4PyO1+4oIfuju241hVk+bFZYUD+AzzCNv7GKNNHe4aa4MWN6RLLhNxe9QlOTnsw0l2XNypr62Q1V8nxZkSY7mW8Hn0hLxTT82mTLuAff2yHPu+w+i0ELkk0BO28apxU1dPPbScHvojRlXTwIBvH3HN6TWdj2YnNFMdGvZgxxFNbi4l/7Gar1FKgi79KOwcm89ATmjONfbQMub+TaeBACefMZ9Q7uzbWeNO3mZpVA8nvM5eleqLemxYoeAQBuYjBjJlAHzQ== cardno:14 321 676"
-  ];
   # Constantine Ter-Matevosian
   breakerzirconia = [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF7HK6hAX/GaUEiWE9zzleIrXHJrIGfxIANE0wL6j2JV terkot1010@gmail.com"


### PR DESCRIPTION
Problem: Philipp is leaving our company, so we need to revoke all accesses that he has.

Solution: Remove his ssh key from the list and also remove his user from the wheel.