### PR TITLE
[Chore] Add staging.ment.serokell.team to known hosts

### DIFF
--- a/modules/ssh-hostkeys.nix
+++ b/modules/ssh-hostkeys.nix
@@ -19,5 +19,6 @@ rec {
     "staging.edna.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAdeUbotl2b/CbCmXWZ0UBkp0kbritHc9Sw//UnFIJi1" ; };
     "www.tezosagora.org" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3YKZ2BSk/Ysb/qfUVQSbHOkkiALiVjv1DAKTKQFhp3"; };
     "algenib.pegasus.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPKGJVl1ob4KAYGPcJkHdoZMLgnOLDNsyKIgJI/iScAt"; };
+    "staging.ment.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMTEXN9yBPSTdFRtOkJGt/CzlemqS/bSzbsOGDRvU/U/"; };
   };
 }


### PR DESCRIPTION
Problem: We need to add staging.ment.serokell.team to known hosts for the CD to work.

Solution: Add pubKey for staging.ment.serokell.team.