### PR TITLE
[Chore] Add vault login to terraform app

### DIFF
--- a/lib/terraform.nix
+++ b/lib/terraform.nix
@@ -1,26 +1,35 @@
 { nixpkgs, lib, ...}:
 let
   inherit (lib) nameValuePair mapAttrs' genAttrs;
-  inherit (builtins) toString;
+  inherit (builtins) toString toJSON;
   addTFPrefix = mapAttrs' (n: nameValuePair "tf-${n}");
   defaultSubDir = "$(mktemp -d)";
 in
 { system ? "x86_64-linux"
 , pkgs ? nixpkgs.legacyPackages.${system}
 , terraform ? pkgs.terraform
-, tfConfig ? null
+, tfConfigAst ? null
 , subdir ? defaultSubDir
 , backend ? true
 }:
 rec {
+  tfConfig = pkgs.writeText "config.tf.json" (toJSON tfConfigAst.config);
+
   mkApp = let
     defaultSubDir = subdir;
     defaultBackend = backend;
     defaultTFConfig = tfConfig;
+
+    vaultLogin = if tfConfigAst.config ? "provider"."vault"."address" then ''
+    export VAULT_ADDR='${tfConfigAst.config."provider"."vault"."address"}'
+    ${pkgs.vault}/bin/vault token lookup >/dev/null 2>&1 || ${pkgs.vault}/bin/vault login -method=oidc
+    '' else "";
+
   in { command, tfConfig ? defaultTFConfig, subdir ? defaultSubDir, backend ? defaultBackend }: {
     type = "app";
     program = toString (pkgs.writers.writeBash command ''
       pushd ${toString subdir} >/dev/null
+      ${vaultLogin}
       if [[ -e config.tf.json ]]; then rm -f config.tf.json; fi
       cp ${tfConfig} config.tf.json \
         && ${terraform}/bin/terraform init ${if backend then "-upgrade" else "-backend=false"} \


### PR DESCRIPTION
Problem: When using terraform, we often need vault access.

Solution: Add vault login to terraform app script to avoid manual login.