### PR TITLE
[INT-243] Support biham in ssh known hosts

### DIFF
--- a/modules/ssh-hostkeys.nix
+++ b/modules/ssh-hostkeys.nix
@@ -22,5 +22,6 @@ rec {
     "staging.ment.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMTEXN9yBPSTdFRtOkJGt/CzlemqS/bSzbsOGDRvU/U/"; };
     "anadolu.pegasus.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICCCIIDZGy6K9+j5WsU+ESMOecgM2Vw7tbVDHb6QGhbW"; };
     "alkabar.pegasus.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICLDHgTk2KG/2AWaIOudYEigQ8vSCwU63ea8wZ3vnXo9"; };
+    "biham.pegasus.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE9HYKeUNkKcMgqfJ86BYdLE90FRgWwxx+qEiEp70Md2"; };
   };
 }


### PR DESCRIPTION
Problem: we would like to support in CI the prod env for haskell certification

Solution: Add the VM's ssh host key to our list of known hosts