### PR TITLE
Make wireguard allowed IPs configurable

### DIFF
--- a/modules/wireguard-monitoring-darwin.nix
+++ b/modules/wireguard-monitoring-darwin.nix
@@ -4,10 +4,17 @@ let
   wireguard-ip = config.wireguard-ip-address;
 
 in {
-  options.wireguard-ip-address = lib.mkOption {
-    type = lib.types.str;
-    description = "IP address for the wireguard interface (in the 172.21.0.0/16 subnet)";
-    example = "172.21.0.3";
+  options = {
+    wireguard-ip-address = lib.mkOption {
+      type = lib.types.str;
+      description = "IP address for the wireguard interface (in the 172.21.0.0/16 subnet)";
+      example = "172.21.0.3";
+    };
+    wireguard-allowed-ips = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = "AllowedIPs list";
+      default = [ "172.21.0.1/32" ];
+    };
   };
 
   config = {
@@ -31,7 +38,7 @@ in {
 
       # set up link to polis
       peers = [{
-        allowedIPs = [ "172.21.0.1/32" ];
+        allowedIPs = config.wireguard-allowed-ips;
         endpoint = "polis.sagittarius.serokell.team:51820";
         publicKey = "gOS8bfFuFJmEpaZa19i2Q62gKAaTyL+XWCJvmxekqy8=";
       }];

--- a/modules/wireguard-monitoring.nix
+++ b/modules/wireguard-monitoring.nix
@@ -4,10 +4,17 @@ let
   wireguard-ip = config.wireguard-ip-address;
 
 in {
-  options.wireguard-ip-address = lib.mkOption {
-    type = lib.types.str;
-    description = "IP address for the wireguard interface (in the 172.21.0.0/16 subnet)";
-    example = "172.21.0.3";
+  options = {
+    wireguard-ip-address = lib.mkOption {
+      type = lib.types.str;
+      description = "IP address for the wireguard interface (in the 172.21.0.0/16 subnet)";
+      example = "172.21.0.3";
+    };
+    wireguard-allowed-ips = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = "AllowedIPs list";
+      default = [ "172.21.0.1/32" ];
+    };
   };
 
   config = {
@@ -33,7 +40,7 @@ in {
 
       # set up link to polis
       peers = [{
-        allowedIPs = [ "172.21.0.1/32" ];
+        allowedIPs = config.wireguard-allowed-ips;
         endpoint = "polis.sagittarius.serokell.team:51820";
         publicKey = "gOS8bfFuFJmEpaZa19i2Q62gKAaTyL+XWCJvmxekqy8=";
       }];


### PR DESCRIPTION
Problem: We want some VPN clients to be able to access other clients. However, currently the only allowed IP address is the VPN server.

Solution: Add an option to provide arbitrary allowed IPs for the wireguard client config.