### PR TITLE
Make 'PersistentKeepalive' configurable for VPN clients 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
     darwinModules = {
       common = import ./modules/common.nix;
       serokell-users = import ./modules/serokell-users-darwin.nix;
-      wireguard-monitoring = import ./modules/wireguard-monitoring-darwin.nix;
+      wireguard-monitoring = import ./modules/wireguard-monitoring/darwin.nix;
     };
 
     nixosModules = {
@@ -49,7 +49,7 @@
       upload-daemon = import ./modules/services/upload-daemon.nix;
       hetzner-cloud = import ./modules/virtualization/hetzner-cloud.nix;
       ec2 = import ./modules/virtualization/ec2.nix;
-      wireguard-monitoring = import ./modules/wireguard-monitoring.nix;
+      wireguard-monitoring = import ./modules/wireguard-monitoring/default.nix;
     };
   } // flake-utils.lib.eachDefaultSystem (system:
     # (pinned nix-unstable version does not support aarch64-darwin)

--- a/modules/wireguard-monitoring/common.nix
+++ b/modules/wireguard-monitoring/common.nix
@@ -11,10 +11,16 @@
       description = "AllowedIPs list";
       default = [ "172.21.0.1/32" ];
     };
+    wireguard-peer-persistent-keepalive = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      description = "Optional PersistentKeepalive value for server peer in client config";
+      default = null;
+    };
   };
   polisPeer = {
     allowedIPs = config.wireguard-allowed-ips;
     endpoint = "polis.sagittarius.serokell.team:51820";
     publicKey = "gOS8bfFuFJmEpaZa19i2Q62gKAaTyL+XWCJvmxekqy8=";
+    persistentKeepalive = config.wireguard-peer-persistent-keepalive;
   };
 }

--- a/modules/wireguard-monitoring/common.nix
+++ b/modules/wireguard-monitoring/common.nix
@@ -1,0 +1,20 @@
+{ config, lib, ... }:
+{
+  options = {
+    wireguard-ip-address = lib.mkOption {
+      type = lib.types.str;
+      description = "IP address for the wireguard interface (in the 172.21.0.0/16 subnet)";
+      example = "172.21.0.3";
+    };
+    wireguard-allowed-ips = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      description = "AllowedIPs list";
+      default = [ "172.21.0.1/32" ];
+    };
+  };
+  polisPeer = {
+    allowedIPs = config.wireguard-allowed-ips;
+    endpoint = "polis.sagittarius.serokell.team:51820";
+    publicKey = "gOS8bfFuFJmEpaZa19i2Q62gKAaTyL+XWCJvmxekqy8=";
+  };
+}

--- a/modules/wireguard-monitoring/darwin.nix
+++ b/modules/wireguard-monitoring/darwin.nix
@@ -1,21 +1,10 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, ... }@args:
 
 let
   wireguard-ip = config.wireguard-ip-address;
-
+  common = import ./common.nix args;
 in {
-  options = {
-    wireguard-ip-address = lib.mkOption {
-      type = lib.types.str;
-      description = "IP address for the wireguard interface (in the 172.21.0.0/16 subnet)";
-      example = "172.21.0.3";
-    };
-    wireguard-allowed-ips = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      description = "AllowedIPs list";
-      default = [ "172.21.0.1/32" ];
-    };
-  };
+  inherit (common) options;
 
   config = {
     #networking.firewall.allowedUDPPorts = [
@@ -37,11 +26,7 @@ in {
       privateKeyFile = "/etc/wireguard/secret";
 
       # set up link to polis
-      peers = [{
-        allowedIPs = config.wireguard-allowed-ips;
-        endpoint = "polis.sagittarius.serokell.team:51820";
-        publicKey = "gOS8bfFuFJmEpaZa19i2Q62gKAaTyL+XWCJvmxekqy8=";
-      }];
+      peers = [ common.polisPeer ];
     };
 
     # run process-exporter on the wireguard interface

--- a/modules/wireguard-monitoring/default.nix
+++ b/modules/wireguard-monitoring/default.nix
@@ -2,20 +2,9 @@
 
 let
   wireguard-ip = config.wireguard-ip-address;
-
+  common = import ./common.nix args;
 in {
-  options = {
-    wireguard-ip-address = lib.mkOption {
-      type = lib.types.str;
-      description = "IP address for the wireguard interface (in the 172.21.0.0/16 subnet)";
-      example = "172.21.0.3";
-    };
-    wireguard-allowed-ips = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      description = "AllowedIPs list";
-      default = [ "172.21.0.1/32" ];
-    };
-  };
+  inherit (common) options;
 
   config = {
     networking.firewall.allowedUDPPorts = [
@@ -39,11 +28,7 @@ in {
       privateKeyFile = "/etc/wireguard/secret";
 
       # set up link to polis
-      peers = [{
-        allowedIPs = config.wireguard-allowed-ips;
-        endpoint = "polis.sagittarius.serokell.team:51820";
-        publicKey = "gOS8bfFuFJmEpaZa19i2Q62gKAaTyL+XWCJvmxekqy8=";
-      }];
+      peers = [ common.polisPeer ];
     };
 
     # run process-exporter on the wireguard interface

--- a/modules/wireguard-monitoring/default.nix
+++ b/modules/wireguard-monitoring/default.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, ... }@args:
 
 let
   wireguard-ip = config.wireguard-ip-address;


### PR DESCRIPTION
Problem: Some VPN clients might be behind NAT or firewall and thus they
may not be able to receive incoming messages after some period of time.

Solution: Make it possible to set some 'PersistentKeepalive' value to
workaround this limitation.