### PR TITLE
[OPS-1477] Add cabal check

### DIFF
--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -119,6 +119,11 @@ in
         ${final.hpack}/bin/hpack
         diff -q -r ${src} .
       '';
+
+      cabal-check = src: runCheck "cabal check" ''
+        cd ${src}
+        ${final.cabal-install}/bin/cabal check
+      '';
     };
   };
 }


### PR DESCRIPTION
Problem: In order to publish a package to hackage, it must meet certain requirements, which can be verified using cabal check.

Solution: Add cabal check.
Related to https://github.com/serokell/nix-templates/pull/24