### PR TITLE
[Chore] Enable restarts metrics for systemd services

### DIFF
--- a/modules/common-non-darwin.nix
+++ b/modules/common-non-darwin.nix
@@ -61,6 +61,7 @@
     services.prometheus.exporters.node = {
       enable = true;
       enabledCollectors = [ "systemd" ];
+      extraFlags = [ "--collector.systemd.enable-restarts-metrics" ];
       disabledCollectors = [ "timex" ];
     };
 


### PR DESCRIPTION
Problem: We have added an alert rule for systemd services stuck in a restart loop, this requires systemd restart metrics to be enabled.

Solution: Add --collector.systemd.enable-restarts-metrics to node exporter config.