### PR TITLE
Add to Promtail user_id, override unit if we have a _systemd_user_unit

### DIFF
--- a/modules/wireguard-monitoring/default.nix
+++ b/modules/wireguard-monitoring/default.nix
@@ -58,10 +58,28 @@ in {
               host = config.networking.hostName;
             };
           };
-          relabel_configs = [{
-            source_labels = [ "__journal__systemd_unit" ];
-            target_label = "unit";
-          }];
+          relabel_configs = [
+            {
+              source_labels = [ "__journal__uid" ];
+              target_label = "user_id";
+            }
+            # some explanation to the next two rules.
+            # Important to notice that both have the same target_label: unit.
+            # if we would use only one rule with 2 source_labels, unfortunately only those
+            # labels will be kept where we have both source labels, so the root level services's log entries are gone.
+            # Regaring the 2nd rule's regex: "(.*);(.+)", we want to match only those where the __journal__systemd_user_unit
+            # is not empty, the regex matches and replaces the label with our $2 value which is the value of __journal__systemd_user_unit.
+            {
+              source_labels = [ "__journal__systemd_unit" ];
+              target_label = "unit";
+            }
+            {
+              source_labels = [ "__journal__systemd_unit" "__journal__systemd_user_unit" ];
+              target_label = "unit";
+              regex = "(.*);(.+)";
+              replacement = "$2";
+            }
+          ];
         }];
       };
     };


### PR DESCRIPTION
Problem: we would like to see the logs also for user-level systemd services, until now we saw only accumulated from all services from a user which was inconvenient (user@10xx.service)

Solution: Extend promtail to add also the user_id  and in the case of user-level services use the value of the `_systemd_user_unit` instead of  `_systemd_unit` which is usually `init.scope`

