### PR TITLE
[OPS-1458] Add haskell.nix wrapper for CI

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ lib, gitignore-nix, nixpkgs, deploy-rs, get-tested }: {
+{ lib, gitignore-nix, nixpkgs, deploy-rs, get-tested }: rec {
   src = import ./src.nix { inherit lib gitignore-nix; };
 
   # Extend nixpkgs with multiple overlays
   #   pkgs = pkgsWith nixpkgs.legacyPackages.${system} [ inputs.serokell-nix.overlay ];
   pkgsWith = p: e: p.extend (lib.composeManyExtensions e);
 
-  haskell = import ./haskell.nix { inherit lib; };
+  haskell = import ./haskell.nix { inherit lib nixpkgs; inherit (cabal) getTestedWithVersions; };
 
   systemd = import ./systemd;
 


### PR DESCRIPTION
Problem: Our CI template for libraries allows one to specify ghc-versions so that we can build a library in different configurations. Currently the only configurable thing is the GHC version. We also want to be able to build libraries with different stack.yaml files and stack resolvers.

Solution: Add a haskell.nix wrapper to the library CI capable of building a project with different GHC versions, stack.yaml files, and stack resolvers.