### PR TITLE
Support nginx error logs in promtail scrape configs

### DIFF
--- a/modules/wireguard-monitoring/default.nix
+++ b/modules/wireguard-monitoring/default.nix
@@ -80,9 +80,22 @@ in {
               replacement = "$2";
             }
           ];
-        }];
+        }] ++ (if config.services.nginx.enable
+        then [{
+          job_name = "nginx-error-logs";
+          static_configs = [{
+            targets = [ "localhost" ];
+            labels = {
+              job = "nginx-error-logs";
+              host = config.networking.hostName;
+              __path__ = "/var/log/nginx/*error.log";
+            };
+          }];
+        }] else [ ]);
       };
     };
+
+    users.users.promtail.extraGroups = lib.mkIf config.services.nginx.enable [ "nginx" ];
 
     # wait for wireguard before starting node-exporter
     systemd.services.prometheus-node-exporter.after = [ "wireguard-wg0.service" ];


### PR DESCRIPTION
Problem: we would like to be alerted when something goes wrong in Nginx logs. For this we need to collect these logs.

Solution: we need a conditional promtail scrape config to gather Nginx error logs, based on the presence of Nginx