### PR TITLE
Revemo anadolu's ssh key

### DIFF
--- a/modules/ssh-hostkeys.nix
+++ b/modules/ssh-hostkeys.nix
@@ -19,7 +19,6 @@ rec {
     "www.tezosagora.org" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK3YKZ2BSk/Ysb/qfUVQSbHOkkiALiVjv1DAKTKQFhp3"; };
     "algenib.pegasus.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPKGJVl1ob4KAYGPcJkHdoZMLgnOLDNsyKIgJI/iScAt"; };
     "staging.ment.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMTEXN9yBPSTdFRtOkJGt/CzlemqS/bSzbsOGDRvU/U/"; };
-    "anadolu.pegasus.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICCCIIDZGy6K9+j5WsU+ESMOecgM2Vw7tbVDHb6QGhbW"; };
     "biham.pegasus.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE9HYKeUNkKcMgqfJ86BYdLE90FRgWwxx+qEiEp70Md2"; };
     "[skat.aquarius.serokell.team]:17788" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILyJ3GkPNLcFGYW46Y7k0SDTuNqIOse03nsNOu0OHLVT"; };
   };


### PR DESCRIPTION
Problem: we would like to decommission anadolu, and we'd like to remove its leftovers from this repo too

Solution: remove the vm's pub ssh host key from our list of host keys

related issues: https://issues.serokell.io/issue/SIO-405