### PR TITLE
Add helper script for creating GitHub releases using gh

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -298,7 +298,7 @@
         "type": "github"
       }
     },
-    "get-tested": {
+    "get-tested-src": {
       "flake": false,
       "locked": {
         "lastModified": 1687355864,
@@ -949,7 +949,7 @@
         "deploy-rs": "deploy-rs",
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils",
-        "get-tested": "get-tested",
+        "get-tested-src": "get-tested-src",
         "gitignore-nix": "gitignore-nix",
         "haskell-nix": "haskell-nix",
         "nix": "nix_2",

--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -126,4 +126,6 @@ in
       '';
     };
   };
+
+  github = import ./github.nix { inherit (final) gh git writeShellApplication; };
 }

--- a/overlay/github.nix
+++ b/overlay/github.nix
@@ -1,0 +1,52 @@
+{ gh, git, writeShellApplication }:
+{
+  # autorelease <release-assets> <release-notes> [release-tag]
+  #
+  # release-assets
+  #   A path to the directory with release assets, typically something like "$(nix build .#release)"
+  # release-notes
+  #   Either a path to the file or bare text to use as release notes.
+  # release-tag (optional)
+  #   A tag for the release to be pushed and also to be used as a release title.
+  #   Default value to be used is 'auto-release'.
+  #
+  # If 'release-tag' is 'autorelease' or 'PRERELEASE' env variable is set to 'true'
+  # created release is marked as 'prerelease'.
+  #
+  # 'OVERWRITE_RELEASE' env variable is set to 'true' an existing release with 'release-tag'
+  # will be deleted prior to recreation.
+  #
+  # This script expects 'GH_TOKEN' env variable to be set to a GitHub PAT that is capable of
+  # managing releases in the target repository.
+  #
+  # Usage examples:
+  # autorelease "$(nix build .#release)" "Automatic release on "$(date +\"%Y%m%d%H%M\")""
+  #
+  # autorelease "$(nix build .#release)" ./release-notes.md "v1.0"
+  autorelease = writeShellApplication {
+    name = "autorelease";
+    runtimeInputs = [ gh git ];
+    text = ''
+      release_assets="$1"
+      release_notes="$2";
+      release_tag="''${3:-auto-release}"
+
+      if [[ ''${OVERWRITE_RELEASE:-false} == true ]]; then
+        # Delete release if it exists
+        gh release delete "$release_tag" --yes || true
+      fi
+
+      typeset -a release_args
+      # Create release
+      if [[ $release_tag == "auto-release" || ''${PRERELEASE:-false} == true ]]; then
+        release_args+=("--prerelease")
+      fi
+      if [[ -f $release_notes ]]; then
+        release_args+=("--notes-file" "$release_notes")
+      else
+        release_args+=("--notes" "$release_notes")
+      fi
+      gh release create "$release_tag" --target "$(git rev-parse HEAD)" --title "$release_tag" "''${release_args[@]}" "$release_assets"/*
+    '';
+  };
+}


### PR DESCRIPTION
Problem: Some of our projects have a job in the CI pipeline that creates GitHub release with some release artifacts. We'd like to unify the approach for creating such releases.

Solution: Add autorelease script to 'lib.github.autorelease'.