### PR TITLE
[OPS-1467] Fix missing pkgs in user-level-services.nix

### DIFF
--- a/lib/systemd/user-level-services.nix
+++ b/lib/systemd/user-level-services.nix
@@ -3,7 +3,7 @@
 , pkgs ? nixpkgs.legacyPackages.${system}, ... }:
 let
   mkVM = moduleConfig: serviceConfig: nixpkgs.lib.nixosSystem {
-    inherit system;
+    inherit system pkgs;
     modules = [ ({ ... }: {
 
       imports = [ moduleConfig.module ];


### PR DESCRIPTION
Problem: in one of the consumers of user-level-servics.nix we bumped into a problem where a hand-crafted pkgs was used. As we didn't pass to the nixpkgs.lib.nixosSystem the incoming pkgs, the consumer didn't work as expected.

Solution: pass pkgs to nixpkgs.lib.nixosSystem too