### PR TITLE
[OPS-1161] Add `withHardeningProfile` helper

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -11,7 +11,7 @@
 
   haskell = import ./haskell.nix { inherit lib nixpkgs; inherit (cabal) getTestedWithVersions; };
 
-  systemd = import ./systemd;
+  systemd = import ./systemd { inherit lib; };
 
   types = import ./types.nix { inherit lib; };
 

--- a/lib/systemd/default.nix
+++ b/lib/systemd/default.nix
@@ -1,3 +1,4 @@
+{ lib }:
 {
 
   hardeningProfiles = import ./profiles.nix;
@@ -5,4 +6,9 @@
   hardenServices = import ./harden-services.nix;
 
   userLevelServices = import ./user-level-services.nix;
+
+  withHardeningProfile = profile: serviceConfig: lib.mkMerge [
+    (builtins.mapAttrs (_: lib.mkDefault) profile)
+    serviceConfig
+  ];
 }

--- a/lib/systemd/profiles.nix
+++ b/lib/systemd/profiles.nix
@@ -42,7 +42,6 @@ rec {
     #   "~CLONE_NEWUTS"
     # ];
     RestrictNamespaces = "yes";
-    DeviceAllow = "no";
     IPAddressDeny = "any";
     KeyringMode = "private";
     NoNewPrivileges = "yes";


### PR DESCRIPTION
Problem: We want to harden our systemd services by using previously defined profiles, so we need a way to easily apply them to our systemd service configurations.

Solution: Add withHardeningProfile helper, remove DeviceAllow from profiles, because it is used incorrectly (systemd complains and skips this option), and the semantics of this use is already covered by PrivateDevices.