### PR TITLE
[Chore] Add 'homam' public key to knowHosts

### DIFF
--- a/modules/ssh-hostkeys.nix
+++ b/modules/ssh-hostkeys.nix
@@ -21,6 +21,7 @@ rec {
       "staging.ment.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMTEXN9yBPSTdFRtOkJGt/CzlemqS/bSzbsOGDRvU/U/"; };
       "biham.pegasus.serokell.team" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE9HYKeUNkKcMgqfJ86BYdLE90FRgWwxx+qEiEp70Md2"; };
       "[skat.aquarius.serokell.team]:17788" = { publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILyJ3GkPNLcFGYW46Y7k0SDTuNqIOse03nsNOu0OHLVT"; };
+      "homam.pegasus.serokell.team" = { publicKey =  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEraUrGl1ovuPyKMeEJtG/XN3OlpSomq0FWhN1BIi2kZ"; };
     };
     knownHostsFiles = [
       (pkgs.writeText "github.keys" ''


### PR DESCRIPTION
Problem: We have a new server which we're planning to access from our nix infra.

Solution: To allow secure ssh access, add 'homam' public ssh key to the list of knownHosts.