### PR TITLE
[Chore] Relabel '__journal_container_name' when docker is enabled

### DIFF
--- a/modules/wireguard-monitoring/default.nix
+++ b/modules/wireguard-monitoring/default.nix
@@ -79,9 +79,11 @@ in {
               regex = "(.*);(.+)";
               replacement = "$2";
             }
-          ];
-        }] ++ (if config.services.nginx.enable
-        then [{
+          ] ++ lib.optional (config.virtualisation.docker.enable) {
+            source_labels = [ "__journal_container_name" ];
+            target_label = "container";
+          };
+        }] ++ (lib.optional (config.services.nginx.enable) {
           job_name = "nginx-error-logs";
           static_configs = [{
             targets = [ "localhost" ];
@@ -91,7 +93,7 @@ in {
               __path__ = "/var/log/nginx/*error.log";
             };
           }];
-        }] else [ ]);
+        });
       };
     };
 


### PR DESCRIPTION
Problem: Some of our services run as containers orchestrated not by systemd. Currently, logs for such containers aren't easily searchable in promtail.

Solution: Add '__journal_container_name' to the promtail relabeling in case docker is enabled within the configuration