### PR TITLE
[Chore] Remove 'nixpkgs.overlay' from 'common' module

### DIFF
--- a/modules/common-non-darwin.nix
+++ b/modules/common-non-darwin.nix
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # configuration options that do not exist for nix-darwin
-{ lib, pkgs, config, options, inputs, ... }:
+{ lib, pkgs, config, options, ... }:
 {
   imports = [
     ./services/nginx.nix

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: 2020 Serokell <https://serokell.io/>
 #
 # SPDX-License-Identifier: MPL-2.0
-
-{ lib, pkgs, config, options, inputs, ... }:
+{ lib, pkgs, config, options, ... }:
 {
   imports = [
     ./ssh-hostkeys.nix
@@ -35,9 +34,6 @@
       experimental-features = nix-command flakes
     '';
 
-
-    nixpkgs.overlays =
-      [ (import ./../overlay) ];
 
     nix.nixPath = [ "nixpkgs=/etc/nix/nixpkgs" ];
 


### PR DESCRIPTION
Problem: For historical reasons, this overlay existed and was using serokell-nix's 'inputs', which in some cases causes issues (see #101). However, nowadays, the overlay only provides utilities used by the CI/CD pipelines and thus there is no sense in using it system-wide.

Solution: Remove 'nixpkgs.overlay' from 'common' module, remove 'inputs' from argument attrset for 'common' module as well.