### PR TITLE
[Chore] Overwrite tag with release in 'github.autorelease'

### DIFF
--- a/overlay/github.nix
+++ b/overlay/github.nix
@@ -34,6 +34,11 @@
       if [[ ''${OVERWRITE_RELEASE:-false} == true ]]; then
         # Delete release if it exists
         gh release delete "$release_tag" --yes || true
+        # Delete the tag if it exists to make sure that 'gh release create' uses the latest commit as a tag target
+        if git show-ref --tags "$release_tag" --quiet; then
+          git tag --delete "$release_tag"
+          git push --force --tags
+        fi
       fi
 
       typeset -a release_args


### PR DESCRIPTION
Problem: 'gh release create' pushes the tag only when it doesn't exist, i.e. it won't attempt to update already existing tag with a given name. As a result, subsequent update of a given release (e.g. auto-release) won't update the underlying tag.

Solution: If 'OVERWRITE_RELEASE' flag is provided, both existing release and tag are deleted.