### PR TITLE
[OPS-1548] Remove balsoft from default wheel users

### DIFF
--- a/modules/serokell-users-options.nix
+++ b/modules/serokell-users-options.nix
@@ -11,7 +11,6 @@ in
       "gromak"
       "jaga"
       "sweater"
-      "balsoft"
       "rvem"
       "sereja"
       "savely"


### PR DESCRIPTION
Problem: We offboarded balsoft and removed his ssh key, we also need to remove him from the default users list.

Solution: Remove balsoft from the default wheel users list.